### PR TITLE
Add parameter to change port and remove terminal logger

### DIFF
--- a/ping_sonar_ros/ping1d_component.py
+++ b/ping_sonar_ros/ping1d_component.py
@@ -57,11 +57,13 @@ class Ping1dComponent(Node):
     self.scan_lenght_:float = self.get_parameter('scan_lenght').value
     self.declare_parameter('mode_auto', 0) # default 0: manual mode, 1: auto mode
     self.mode_auto_:int = self.get_parameter('mode_auto').value
+    self.declare_parameter('port', '/dev/ttyUSB0')
+    self.port_:str = self.get_parameter('port').value
 
     self.param_handler_ptr_ = self.add_on_set_parameters_callback(self.set_param_callback)
 
     ### Make a new Ping
-    self.port = "/dev/ttyUSB0"
+    self.port = self.port_
     self.baudrate = 115200
     self.ping = module.Ping1D()
     self.ping.connect_serial(self.port, self.baudrate)
@@ -136,7 +138,7 @@ class Ping1dComponent(Node):
     range_msg.max_range = float(range_data["scan_length"]/1000) # [m]
     range_msg.range = float(simple_data["distance"]/1000) # [m]
     self.publisher_.publish(range_msg)
-    self.get_logger().info("Publishing range: {}".format(range_msg.range))
+    # self.get_logger().info("Publishing range: {}".format(range_msg.range))
 
     dist_msg = Float32()
     speed_msg = Float32()

--- a/ping_sonar_ros/ping1d_component.py
+++ b/ping_sonar_ros/ping1d_component.py
@@ -58,12 +58,11 @@ class Ping1dComponent(Node):
     self.declare_parameter('mode_auto', 0) # default 0: manual mode, 1: auto mode
     self.mode_auto_:int = self.get_parameter('mode_auto').value
     self.declare_parameter('port', '/dev/ttyUSB0')
-    self.port_:str = self.get_parameter('port').value
+    self.port:str = self.get_parameter('port').value
 
     self.param_handler_ptr_ = self.add_on_set_parameters_callback(self.set_param_callback)
 
     ### Make a new Ping
-    self.port = self.port_
     self.baudrate = 115200
     self.ping = module.Ping1D()
     self.ping.connect_serial(self.port, self.baudrate)


### PR DESCRIPTION
The port name can change when multiple devices are attached to the computer. Having a variable that can be used to change it quickly would make the package much more portable. Also, the current version prints a lot of data to the terminal, so we can always use ```ros2 topic echo``` to print it if necessary. 